### PR TITLE
Add weakref set for opened fonts, close them on quit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/src/spec/*.spec linguist-generated=true

--- a/src/general.lisp
+++ b/src/general.lisp
@@ -2,6 +2,8 @@
 
 (require 'sdl2)
 
+(defvar *fonts* (list) "List of weak refs to fonts.")
+
 (defun init ()
   "Initialize the sdl trutype font API. Does not require a call to sdl-init prior to calling this function. Returns 0 if succesful -1 otherwise"
   (check-rc (ttf-init)))
@@ -16,16 +18,26 @@
   (ttf-was-init))
 
 (defun quit ()
+  (dolist (pointer *fonts*)
+    (let ((ttf-font-struct (tg:weak-pointer-value pointer)))
+      (when ttf-font-struct (close-font ttf-font-struct))))
   (ttf-quit))
 
 (defun open-font (path-to-font point-size)
   "Open a font specified by the path specifier path-to-font sized to integer point-size (based on 72DPI). Returns a ttf-font struct and null on errors"
-  (autocollect (ptr)
-      (check-null (ttf-open-font (namestring path-to-font) point-size))
-    (ttf-close-font ptr)))
+  (let ((font (autocollect (ptr)
+                           (check-null (ttf-open-font (namestring path-to-font) point-size))
+                (ttf-close-font ptr))))
+    (push (tg:make-weak-pointer font) *fonts*)
+    font))
 
 (defun close-font (ttf-font-struct)
   "Frees the memory used by the ttf-font-struct"
   (tg:cancel-finalization ttf-font-struct)
+  (setf *fonts*
+        (remove ttf-font-struct *fonts*
+                :key #'tg:weak-pointer-value
+                :test #'(lambda (l r)
+                          (cffi:pointer-eq (autowrap:ptr l) (autowrap:ptr r)))))
   (ttf-close-font ttf-font-struct)
   (autowrap:invalidate ttf-font-struct))


### PR DESCRIPTION
I've added weakref set for opened fonts to prevent any errors on closing library having refs to fonts in client code. Here's example:
1) We're creating ref to cl-sdl2-ttf font object - https://github.com/pkulev/o2/blob/7a9927d49e5d1ea74c891c6b37feb9d0c0ea8a3c/src/application.lisp#L95
2) We're closing fonts on quit before quitting SDL libraries - https://github.com/pkulev/o2/blob/7a9927d49e5d1ea74c891c6b37feb9d0c0ea8a3c/src/application.lisp#L125
3) Font already closed in cl-sdl2-ttf library, but our code still has ref to it or something.
4) Here we're quitting cl-sdl2-ttf library - https://github.com/pkulev/o2/blob/7a9927d49e5d1ea74c891c6b37feb9d0c0ea8a3c/src/application.lisp#L151
5) After that steps finalizers come to play and everything blows up.

Now with weakrefs library itself can close fonts if they are not closed, or just skip them if they are already closed from client code.

Also I've added fix for proper repo language determination, now it will be determined as CL, not python :smiley: 