### PR TITLE
Fix UB of destructively modifying macro arguments

### DIFF
--- a/src/helpers.lisp
+++ b/src/helpers.lisp
@@ -21,7 +21,7 @@
        ,@(mapcar (lambda (pair)
                    `(when (plusp (logand ,(first pair) ,value))
                       (push ',(second pair) ,pack)))
-                 (nreverse pairs))
+                 (reverse pairs))
        ,pack)))
 
 (defmacro pack-to-bitwise (packed &body pairs)


### PR DESCRIPTION
This was detected by a warning on the upcoming SBCL 2.0.7.
This causes cascading errors in other systems which depend on this one
http://report.quicklisp.org/2020-07-24/failure-report/cl-sdl2-ttf.html#sdl2-ttf
