### PR TITLE
Define functions for getting and setting the font outline

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -11,4 +11,6 @@
            #:quit
            #:open-font
            #:close-font
-           #:bold #:italic #:underline #:strike-through))
+           #:bold #:italic #:underline #:strike-through
+	   #:set-font-outline
+	   #:get-font-outline))

--- a/src/style.lisp
+++ b/src/style.lisp
@@ -26,10 +26,15 @@
      style))
 
 (define-function-get-style "TTF_GetFontStyle" font-style %sdl2-ttf-get-font-style)
-(define-function-get-style "TTF_GetFontOutline" font-outline %sdl2-ttf-get-font-outline)
 
 (define-function-set-style "TTF_SetFontStyle" set-font-style %sdl2-ttf-set-font)
-(define-function-set-style "TTF_SetFontOutline" set-font-outline %sdl2-ttf-set-font-outline)
 
 (defsetf font-style set-font-style)
-(defsetf font-outline set-font-outline)
+
+(defun set-font-outline (font outline-size)
+  "Creates an outline of OUTLINE-SIZE when FONT is rendered."
+  (ttf-set-font-outline font outline-size))
+
+(defun get-font-outline (font)
+  "Return the outline size for FONT."
+  (ttf-get-font-outline font))


### PR DESCRIPTION
Hello,

Thanks for your work on cl-sdl2-ttf. I made some small changes to set-font-outline and get-font-outline because I was running into trouble with creating an outline. The set-font-outline was originally expecting a list instead of the number of outline pixels.