### PR TITLE
Removed finalizers, optimized support for LispWorks, bug fix in examples.

### DIFF
--- a/examples/basic.lisp
+++ b/examples/basic.lisp
@@ -1,5 +1,6 @@
 (in-package :ttf-examples)
 
+#-lispworks
 (require 'sdl2-ttf)
 
 (defun basic-example ()

--- a/examples/gl-example.lisp
+++ b/examples/gl-example.lisp
@@ -1,7 +1,10 @@
 (in-package :ttf-examples)
 
+#-lispworks
 (require :cl-opengl)
+#-lispworks
 (require :sdl2-ttf)
+#-lispworks
 (require :mathkit)
 
 (defun create-gl-array (type lisp-array)
@@ -115,7 +118,7 @@
             (gl:tex-image-2d :texture-2d
                              0
                              :rgba
-                             (surface-width texture-surface)
+                             (/ (surface-pitch texture-surface) 4)
                              (surface-height texture-surface)
                              0
                              :rgba

--- a/examples/package.lisp
+++ b/examples/package.lisp
@@ -3,7 +3,6 @@
 (defpackage :ttf-examples
   (:use #:cl
         #:alexandria
-        #:tg
         #:cffi
         #:sdl2)
   (:export :basic-example

--- a/sdl2-ttf.asd
+++ b/sdl2-ttf.asd
@@ -8,7 +8,11 @@
     :author "Bryan Baraoidan"
     :license "MIT"
     :version "1.0"
-    :depends-on (:alexandria :defpackage-plus :cl-autowrap :sdl2 :cffi-libffi :trivial-garbage)
+    :depends-on
+    #+lispworks
+    (:alexandria :defpackage-plus :cl-autowrap :sdl2)
+    #-lispworks
+    (:alexandria :defpackage-plus :cl-autowrap :sdl2 :cffi-libffi)
     :pathname "src"
     :serial t
     :components ((:file "package")

--- a/src/general.lisp
+++ b/src/general.lisp
@@ -1,5 +1,6 @@
 (in-package :sdl2-ttf)
 
+#-lispworks
 (require 'sdl2)
 
 (defvar *fonts* (list) "List of weak refs to fonts.")
@@ -17,27 +18,14 @@
   "Returns 1 if initialized zero otherwise."
   (ttf-was-init))
 
-(defun quit ()
-  (dolist (pointer *fonts*)
-    (let ((ttf-font-struct (tg:weak-pointer-value pointer)))
-      (when ttf-font-struct (close-font ttf-font-struct))))
-  (ttf-quit))
+(defun quit () (ttf-quit))
 
 (defun open-font (path-to-font point-size)
   "Open a font specified by the path specifier path-to-font sized to integer point-size (based on 72DPI). Returns a ttf-font struct and null on errors"
-  (let ((font (autocollect (ptr)
-                           (check-null (ttf-open-font (namestring path-to-font) point-size))
-                (ttf-close-font ptr))))
-    (push (tg:make-weak-pointer font) *fonts*)
-    font))
+  (check-null (ttf-open-font (namestring path-to-font) point-size)))
 
 (defun close-font (ttf-font-struct)
   "Frees the memory used by the ttf-font-struct"
-  (tg:cancel-finalization ttf-font-struct)
-  (setf *fonts*
-        (remove ttf-font-struct *fonts*
-                :key #'tg:weak-pointer-value
-                :test #'(lambda (l r)
-                          (cffi:pointer-eq (autowrap:ptr l) (autowrap:ptr r)))))
   (ttf-close-font ttf-font-struct)
   (autowrap:invalidate ttf-font-struct))
+

--- a/src/render.lisp
+++ b/src/render.lisp
@@ -2,19 +2,22 @@
 ;;(mainly due to no support for pass by value as of writing 6-22-2015)
 
 (in-package :sdl2-ttf)
-
+#-lispworks
 (cffi:defcstruct (sdl-color)
   (r :uint8)
   (g :uint8)
   (b :uint8)
   (a :uint8))
 
+
+#-lispworks
 (defun create-sdl-color-list (red green blue alpha)
   `(r ,red
     g ,green
     b ,blue
     a ,alpha))
 
+#-lispworks
 (defmacro define-render-function (style encoding)
   (let* ((foreign-function-name (format 'nil "TTF_Render~a_~a" encoding style))
          (wrapper-function-name (function-symbol "render-" encoding "-" style))
@@ -23,19 +26,18 @@
          :pointer
          ((font :pointer) (text :string) (color (:struct sdl-color)))
          (font text red green blue alpha)
-       (autocollect (ptr)
-           ;;We need to wrap this manually since we are providing the function ourselves
-           (check-null (sdl2-ffi::make-sdl-surface
-                        :ptr (,low-level-lisp-name (autowrap:ptr font)
-                                                   text
-                                                   (create-sdl-color-list red
-                                                                          green
-                                                                          blue
-                                                                          alpha))))
-         (sdl-free-surface ptr)))))
+       (check-null (sdl2-ffi::make-sdl-surface
+                    :ptr (,low-level-lisp-name
+                          (autowrap:ptr font)
+                          text
+                          (create-sdl-color-list red
+                                                 green
+                                                 blue
+                                                 alpha)))))))
 
 ;;Shaded functions require a separate macro because issue #2 (bg and fg colors)
 ;;There is some repeated code here
+#-lispworks
 (defmacro define-shaded-render-function (encoding)
   (let* ((style "Shaded")
          (foreign-function-name (format 'nil "TTF_Render~a_~a" encoding style))
@@ -45,31 +47,108 @@
          :pointer
          ((font :pointer) (text :string) (fg (:struct sdl-color)) (bg (:struct sdl-color)))
          (font text fg-red fg-green fg-blue fg-alpha bg-red bg-green bg-blue bg-alpha)
-       (autocollect (ptr)
-           (check-null (sdl2-ffi::make-sdl-surface
-                        :ptr (,low-level-lisp-name (autowrap:ptr font)
-                                                   text
-                                                   (create-sdl-color-list fg-red
-                                                                          fg-green
-                                                                          fg-blue
-                                                                          fg-alpha)
-                                                   (create-sdl-color-list bg-red
-                                                                          bg-green
-                                                                          bg-blue
-                                                                          bg-alpha))))
-         (sdl-free-surface ptr)))))
+       (check-null (sdl2-ffi::make-sdl-surface
+                    :ptr (,low-level-lisp-name (autowrap:ptr font)
+                                               text
+                                               (create-sdl-color-list fg-red
+                                                                      fg-green
+                                                                      fg-blue
+                                                                      fg-alpha)
+                                               (create-sdl-color-list bg-red
+                                                                      bg-green
+                                                                      bg-blue
+                                                                      bg-alpha)))))))
+#+lispworks
+(fli:define-c-struct sdl-color
+  (r :byte)
+  (g :byte)
+  (b :byte)
+  (a :byte))
+
+#+lispworks
+(defun encoding-keyword (encoding-str)
+  (cond ((string= encoding-str "Text") :ascii)
+        ((string= encoding-str "UTF8") :utf-8)
+        ((string= encoding-str "UNICODE") :unicode)
+        (t (error
+            (format nil "Unsupported encoding: ~A~%." encoding-str)))))
+            
+#+lispworks
+(defmacro define-render-function (style encoding)
+  (let* ((foreign-function-name (format 'nil "TTF_Render~a_~a" encoding style))
+         (wrapper-function-name (function-symbol "render-" encoding "-" style))
+         (low-level-lisp-name (function-symbol "%sdl-" wrapper-function-name)))
+    `(progn
+       (fli:define-foreign-function (,low-level-lisp-name ,foreign-function-name)
+           ((font :pointer) (text :pointer) (color (:struct sdl-color)))
+         :result-type :pointer)
+       (defun ,wrapper-function-name (font text red green blue alpha)
+         (let ((color-object (fli:allocate-foreign-object :type 'sdl-color)))
+           (setf (fli:foreign-slot-value color-object 'r) red)
+           (setf (fli:foreign-slot-value color-object 'g) green)
+           (setf (fli:foreign-slot-value color-object 'b) blue)
+           (setf (fli:foreign-slot-value color-object 'a) alpha)
+           (prog1
+               (check-null
+                (sdl2-ffi::make-sdl-surface
+                 :ptr (,low-level-lisp-name (autowrap:ptr font)
+                                              (fli:convert-to-foreign-string
+                                               text
+                                               :external-format (encoding-keyword ,encoding)
+                                               :allocation :static)
+                                              color-object)))
+             (fli:free-foreign-object color-object))))
+       (export ',wrapper-function-name))))
+
+#+lispworks
+(defmacro define-shaded-render-function (encoding)
+  (let* ((style "Shaded")
+         (foreign-function-name (format 'nil "TTF_Render~a_~a" encoding style))
+         (wrapper-function-name (function-symbol "render-" encoding "-" style))
+         (low-level-lisp-name (function-symbol "%sdl-" wrapper-function-name)))
+    `(progn
+       (fli:define-foreign-function (,low-level-lisp-name ,foreign-function-name)
+           ((font :pointer) (text :pointer) (fg-color (:struct sdl-color)) (bg-color (:struct sdl-color)))
+         :result-type :pointer)
+       (defun ,wrapper-function-name (font text fg-red fg-green fg-blue fg-alpha
+                                           bg-red bg-green bg-blue bg-alpha)
+         (let ((color-object-fg (fli:allocate-foreign-object :type 'sdl-color))
+               (color-object-bg (fli:allocate-foreign-object :type 'sdl-color)))
+           (setf (fli:foreign-slot-value color-object-fg 'r) fg-red)
+           (setf (fli:foreign-slot-value color-object-fg 'g) fg-green)
+           (setf (fli:foreign-slot-value color-object-fg 'b) fg-blue)
+           (setf (fli:foreign-slot-value color-object-fg 'a) fg-alpha)
+           (setf (fli:foreign-slot-value color-object-bg 'r) bg-red)
+           (setf (fli:foreign-slot-value color-object-bg 'g) bg-green)
+           (setf (fli:foreign-slot-value color-object-bg 'b) bg-blue)
+           (setf (fli:foreign-slot-value color-object-bg 'a) bg-alpha)
+           (prog1
+               (check-null
+                (sdl2-ffi::make-sdl-surface
+                 :ptr (,low-level-lisp-name (autowrap:ptr font)
+                                              (fli:convert-to-foreign-string
+                                               text
+                                               :external-format (encoding-keyword ,encoding)
+                                               :allocation :static)
+                                              color-object-fg
+                                              color-object-bg)))
+             (fli:free-foreign-object color-object-fg)
+             (fli:free-foreign-object color-object-bg))))
+       (export ',wrapper-function-name))))
+
 
 (define-render-function "Solid" "Text")
 (define-render-function "Solid" "UTF8")
 (define-render-function "Solid" "UNICODE")
-(define-render-function "Solid" "Glyph")
-
+#-lispworks
+(define-render-function "Solid" "Glyph")  
 (define-render-function "Blended" "UTF8")
 (define-render-function "Blended" "Text")
 (define-render-function "Blended" "UNICODE")
-(define-render-function "Blended" "Glyph")
-
+#-lispworks
+(define-render-function "Blended" "Glyph")  
 (define-shaded-render-function "Text")
 (define-shaded-render-function "UTF8")
 (define-shaded-render-function "UNICODE")
+#-lispworks
 (define-shaded-render-function "Glyph")

--- a/src/render.lisp
+++ b/src/render.lisp
@@ -3,6 +3,20 @@
 
 (in-package :sdl2-ttf)
 
+#+lispworks
+(fli:define-c-struct sdl-color
+  (r :byte)
+  (g :byte)
+  (b :byte)
+  (a :byte))
+
+#-lispworks
+(cffi:defcstruct (sdl-color)
+  (r :uint8)
+  (g :uint8)
+  (b :uint8)
+  (a :uint8))
+
 #-lispworks
 (defun create-sdl-color-list (red green blue alpha)
   `(r ,red
@@ -51,12 +65,8 @@
                                                                       bg-green
                                                                       bg-blue
                                                                       bg-alpha)))))))
-#+lispworks
-(fli:define-c-struct sdl-color
-  (r :byte)
-  (g :byte)
-  (b :byte)
-  (a :byte))
+
+
 
 #+lispworks
 (defun encoding-keyword (encoding-str)


### PR DESCRIPTION
Hi, there,
Thank you for your great works! I'm interested in using cl-sdl2-ttf in my own code adventures. After trying out code, I have eliminated some bugs and made some improvements, and I would like to share them with you and others.

This PR contains three major improvements/fixes.
1. Removed finalizers, i.e. TRIVIAL-GARBAGE. Finalizers can cause problems, as they are not thread-safe and the time it triggers garbage collection can be randomized. It can also be misleading for newcomers who has no idea about how finalizers work, see  issues like [this](https://github.com/Failproofshark/cl-sdl2-ttf/issues/22). Recently CL-SDL2 has dropped finalizers and is welcomed by the community, so I guess it's time for CL-SDL2-TTF to take the shot. We should let users manage the fonts/surfaces allocated by the program, like writing a with-macro, after all, it's very easy to do so in Lisp.
2. Since I've been using LispWorks, I have rewritten the code in src/render.lisp to better support it. I have done two things:
    1. Dropped libffi dependency for LispWorks. Libffi can be hard to compile in some platforms, and it is used in the code solely to support passing `struct sdl-color` as arguments in FFI call. As LispWorks' own FFI has already supported passing structs as arguments, we can omit this redundency by writing a bare-metal FFI call for LispWorks FFI.
    2. Fixed glyph rendering functions, like `TTF_RenderGlyph_Shaded`. In these special kind of functions, the second argument to be passed should be an `uint16`, wheras the master code mistakenly passed a C-string. I have fixed this bug for my LispWorks implementation.
3. Fixed a bug in examples/gl-example.lisp that can cause the text rendered as garbage on Windows platform. It turns out that the `surface-pixels` in cl-sdl2 can have their own layout of pixels by adding paddings, so `surface-width` does not represent how much bytes are in a single scanline of the image. Changed it to `surface-pitch / 4`. 

Regards,
niwtr 